### PR TITLE
ConfigLoader.ignore defaults to including node_modules.

### DIFF
--- a/lib/config-loader.js
+++ b/lib/config-loader.js
@@ -39,6 +39,7 @@ function ConfigLoader(options) {
   options.envFile = options.envFile || 'config.env.json';
   options.filename = options.filename || 'config.json';
   options.ttl = options.ttl || 3600;
+  options.ignore = options.ignore || ['node_modules'];
 
   
   debug('created with options', options);


### PR DESCRIPTION
@Schoonology Do you want this change, or can we throw it away?
